### PR TITLE
feat/dor-requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,14 +135,14 @@
     </div>
 
     <div>
-      <label for="regions">Global Tables:
+      <label for="regions">Number of Data Centers:
         <input type="text" id="regionsInp" style="display: none; width: 80px; cursor: pointer;">
         <span id="regionsDsp">1</span>
         <span class="info-icon">i
             <span class="tooltip-text">Enter the number of additional regions where your data is replicated as a Global Table.</span>
         </span>
         </label>
-        <input type="range" id="regions" min="0" max="24" step="1" value="0">
+        <input type="range" id="regions" min="1" max="24" step="1" value="1">
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 <body>
 <div class="container">
   <canvas id="chart" width="800" height="400"></canvas>
-  <div class="cost">
+  <div class="cost" style="display: none;">
     <p>
       <span id="costDiff">$0</span>
       <span id="costDiffMo">/mo</span>

--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
     </div>
   </div>
 
-  <a href="#" id="consistencyLink" style="display: none;">▼ Consistency</a>
+  <a href="#" id="consistencyLink">▼ Consistency</a>
 
   <div id="consistencyParams" style="display: none;">
     <div style="display: none;">
@@ -177,11 +177,11 @@
     <div class="slider-container">
       <label>Reads: <span id="readConstDsp">Strongly Consistent</span>
         <span class="info-icon">i
-            <span class="tooltip-text">Enter read operations as eventually consistent, strongly consistent and/or transactional as a percentage.</span>
+            <span class="tooltip-text">Enter read operations as eventually consistent or strongly consistent as a percentage.</span>
         </span>
       </label>
       <input type="range" id="readConst" class="slider" min="0" max="100" value="100">
-      <input type="range" id="readTrans" class="slider" min="0" max="100" value="0">
+      <input type="range" id="readTrans" class="slider" min="0" max="100" value="0" style="display: none;">
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -32,60 +32,45 @@
     </label>
   </div>
 
-
   <div id="costParams">
     <span id="costs" class="costs"></span>
   </div>
   <a href="#" id="costLink">▲ Costs</a>
 
-  <div id="demandParams">
-    <div>
-      <label for="demand">On Demand:
-        <input type="text" id="demandInp" style="display: none; width: 80px; cursor: pointer;">
-        <span id="demandDsp" style="cursor: pointer;">50K</span> ops/sec
-        <span class="info-icon">i
-                    <span class="tooltip-text">Enter the number of operations per second that your workload will use.</span>
+  <div>
+    <label for="baseline">Baseline:
+      <input type="text" id="baselineInp" style="display: none; width: 80px; cursor: pointer;">
+      <span id="baselineDsp">50K</span> ops/sec
+      <span class="info-icon">i
+                    <span class="tooltip-text">Enter the number of operations per second that your workload needs during off-peak periods.</span>
                 </span>
-      </label>
+    </label>
+    <input type="range" id="baseline" min="1000" max="1000000" step="1000" value="50000">
+  </div>
 
-      <input type="range" id="demand" min="1000" max="1000000" step="1000" value="50000">
-    </div>
+  <div>
+    <label for="peak">Peak:
+      <input type="text" id="peakInp" style="display: none; width: 80px; cursor: pointer;">
+      <span id="peakDsp">500K</span> ops/sec
+      <span class="info-icon">i
+                    <span class="tooltip-text">Enter the maximum number of operations per second that your workload needs during peak periods.</span>
+                </span>
+    </label>
+    <input type="range" id="peak" min="1000" max="1000000" step="1000" value="500000">
+  </div>
+
+  <div>
+    <label for="peakWidth">Peak:
+      <input type="text" id="peakWidthInp" style="display: none; width: 80px; cursor: pointer;">
+      <span id="peakWidthDsp">1</span> hours per day
+      <span class="info-icon">i
+                    <span class="tooltip-text">Enter the number of hours per day that your workload operates at peak.</span>
+                </span>
+    </label>
+    <input type="range" id="peakWidth" min="1" max="24" value="1">
   </div>
 
   <div id="provisionedParams" style="display: none;">
-    <div>
-      <label for="baseline">Baseline:
-        <input type="text" id="baselineInp" style="display: none; width: 80px; cursor: pointer;">
-        <span id="baselineDsp">50K</span> ops/sec
-        <span class="info-icon">i
-                    <span class="tooltip-text">Enter the number of operations per second that your workload needs during off-peak periods.</span>
-                </span>
-      </label>
-      <input type="range" id="baseline" min="1000" max="1000000" step="1000" value="50000">
-    </div>
-
-    <div>
-      <label for="peak">Peak:
-        <input type="text" id="peakInp" style="display: none; width: 80px; cursor: pointer;">
-        <span id="peakDsp">500K</span> ops/sec
-        <span class="info-icon">i
-                    <span class="tooltip-text">Enter the maximum number of operations per second that your workload needs during peak periods.</span>
-                </span>
-      </label>
-      <input type="range" id="peak" min="1000" max="1000000" step="1000" value="500000">
-    </div>
-
-    <div>
-      <label for="peakWidth">Peak:
-        <input type="text" id="peakWidthInp" style="display: none; width: 80px; cursor: pointer;">
-        <span id="peakWidthDsp">1</span> hours per day
-        <span class="info-icon">i
-                    <span class="tooltip-text">Enter the number of hours per day that your workload operates at peak.</span>
-                </span>
-      </label>
-      <input type="range" id="peakWidth" min="1" max="24" value="1">
-    </div>
-
     <div>
       <label for="reservedCapacity">Reserved Capacity:
         <input type="text" id="reservedCapacityInp" style="display: none; width: 80px; cursor: pointer;">
@@ -221,4 +206,3 @@
 
 </body>
 </html>
-

--- a/index.html
+++ b/index.html
@@ -108,6 +108,17 @@
     <input type="range" id="ratio" min="0" max="100" step="1" value="50">
   </div>
 
+  <div>
+    <label for="itemSizeB">Operation Size:
+      <input type="text" id="itemSizeInp" style="display: none; width: 80px; cursor: pointer;">
+      <span id="itemSizeDsp">1 KB</span>
+      <span class="info-icon">i
+            <span class="tooltip-text">Enter your average operation size (all attributes).</span>
+        </span>
+    </label>
+    <input type="range" id="itemSizeB" min="64" max="409600" step="64" value="1024">
+  </div>
+
   <a href="#" id="tableLink">▼ Tables</a>
 
   <div id="tableParams" style="display: none;">
@@ -138,17 +149,6 @@
   <a href="#" id="storageLink">▼ Storage</a>
 
   <div id="storageParams" style="display: none;">
-    <div>
-      <label for="itemSizeB">Item Size:
-        <input type="text" id="itemSizeInp" style="display: none; width: 80px; cursor: pointer;">
-        <span id="itemSizeDsp">1 KB</span>
-        <span class="info-icon">i
-            <span class="tooltip-text">Enter your average item size (all attributes).</span>
-        </span>
-      </label>
-      <input type="range" id="itemSizeB" min="64" max="409600" step="64" value="1024">
-    </div>
-
     <div>
       <label for="storageGB">Storage:
         <input type="text" id="storageInp" style="display: none; width: 80px; cursor: pointer;">

--- a/src/app.js
+++ b/src/app.js
@@ -233,7 +233,8 @@ export function updateReadConsistency() {
     } else if (eventuallyConsistent === 100) {
         display.innerText = `Eventually Consistent`;
     } else {
-        display.innerText = `Strongly Consistent: ${strongConsistent}%, Eventually Consistent: ${eventuallyConsistent}%, Transactional: ${transactional}%`;
+        // display.innerText = `Strongly Consistent: ${strongConsistent}%, Eventually Consistent: ${eventuallyConsistent}%, Transactional: ${transactional}%`;
+        display.innerText = `Strongly Consistent: ${strongConsistent}%, Eventually Consistent: ${eventuallyConsistent}%`;
     }
     updateAll();
 }

--- a/src/app.js
+++ b/src/app.js
@@ -88,7 +88,6 @@ export function toggleSection(linkId, sectionId, expandedText, collapsedText) {
     });
 }
 
-setupSliderInteraction('demandDsp', 'demandInp', 'demand', formatNumber);
 setupSliderInteraction('baselineDsp', 'baselineInp', 'baseline', formatNumber);
 setupSliderInteraction('peakDsp', 'peakInp', 'peak', formatNumber);
 setupSliderInteraction('peakWidthDsp', 'peakWidthInp', 'peakWidth', value => value);
@@ -106,37 +105,23 @@ document.getElementById('chart').onclick = function (event) {
 };
 
 document.querySelector('input[name="pricing"][value="demand"]').addEventListener('change', (event) => {
-    const demandParams = document.getElementById('demandParams');
     const provisionedParams = document.getElementById('provisionedParams');
     if (event.target.checked) {
-        demandParams.style.display = 'block';
         provisionedParams.style.display = 'none';
-        chart.data.datasets[1].hidden = false;
-        chart.data.datasets[2].hidden = true;
         updateAll();
     }
 });
 
 document.querySelector('input[name="pricing"][value="provisioned"]').addEventListener('change', (event) => {
-    const demandParams = document.getElementById('demandParams');
     const provisionedParams = document.getElementById('provisionedParams');
     if (event.target.checked) {
-        demandParams.style.display = 'none';
         provisionedParams.style.display = 'block';
-        chart.data.datasets[1].hidden = true;
-        chart.data.datasets[2].hidden = false;
         updateAll();
     }
 });
 
 document.getElementById('tableClass').addEventListener('change', (event) => {
     cfg.tableClass = event.target.value;
-    updateAll();
-});
-
-document.getElementById('demand').addEventListener('input', (event) => {
-    cfg.demand = parseInt(event.target.value);
-    document.getElementById('demandDsp').innerText = formatNumber(cfg.demand);
     updateAll();
 });
 
@@ -262,19 +247,12 @@ getQueryParams();
 
 if (cfg.pricing === 'demand') {
     document.querySelector('input[name="pricing"][value="demand"]').checked = true;
-    document.getElementById('demandParams').style.display = 'block';
     document.getElementById('provisionedParams').style.display = 'none';
-    chart.data.datasets[1].hidden = false;
-    chart.data.datasets[2].hidden = true;
 } else if (cfg.pricing === 'provisioned') {
     document.querySelector('input[name="pricing"][value="provisioned"]').checked = true;
-    document.getElementById('demandParams').style.display = 'none';
     document.getElementById('provisionedParams').style.display = 'block';
-    chart.data.datasets[1].hidden = true;
-    chart.data.datasets[2].hidden = false;
 }
 
-document.getElementById('demand').value = cfg.demand;
 document.getElementById('baseline').value = cfg.baseline;
 document.getElementById('peak').value = cfg.peak;
 document.getElementById('peakWidth').value = cfg.peakWidth;
@@ -284,7 +262,6 @@ document.getElementById('ratio').value = cfg.ratio;
 document.getElementById('regions').value = cfg.regions;
 document.getElementById('daxNodes').value = cfg.daxNodes;
 
-document.getElementById('demandDsp').innerText = formatNumber(cfg.demand);
 document.getElementById('baselineDsp').innerText = formatNumber(cfg.baseline);
 document.getElementById('peakDsp').innerText = formatNumber(cfg.peak);
 document.getElementById('peakWidthDsp').innerText = cfg.peakWidth;

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -73,12 +73,13 @@ function getRatioValues() {
 }
 
 function getDemandValues() {
-    cfg.demand = parseInt(document.getElementById('demand').value);
+    cfg.baselineHours = cfg.hoursPerMonth - cfg.peakHours;
+    cfg.peakHours = cfg.peakWidth * 30;
 }
 
 function getProvisionedValues() {
-    cfg.peakHours = cfg.peakWidth * 30;
     cfg.baselineHours = cfg.hoursPerMonth - cfg.peakHours;
+    cfg.peakHours = cfg.peakWidth * 30;
     cfg.reservedCapacity = parseInt(document.getElementById('reservedCapacity').value) / 100;
 }
 
@@ -137,13 +138,13 @@ export function calculateProvisionedCosts() {
 export function calculateDemandCosts() {
     cfg.readRequestUnitsPerItem = Math.ceil(cfg.itemSizeKB / 4.0);
     cfg.writeRequestUnitsPerItem = Math.ceil(cfg.itemSizeKB);
-    cfg.numberReads = cfg.demand * cfg.readRatio * 3600 * cfg.hoursPerMonth;
+    cfg.numberReads = (cfg.baseline * cfg.readRatio * 3600 * cfg.baselineHours) + (cfg.peak * cfg.readRatio * 3600 * cfg.peakHours);
     cfg.readRequestUnits = (cfg.numberReads * cfg.readEventuallyConsistent * 0.5 * cfg.readRequestUnitsPerItem) +
         (cfg.numberReads * cfg.readStronglyConsistent * cfg.readRequestUnitsPerItem) +
         (cfg.numberReads * cfg.readTransactional * 2 * cfg.readRequestUnitsPerItem);
     cfg.dynamoCostDemandReads = cfg.readRequestUnits * (cfg.tableClass === 'standard' ? cfg.pricePerRRU : cfg.pricePerRRU_IA);
 
-    cfg.numberWrites = cfg.demand * cfg.writeRatio * 3600 * cfg.hoursPerMonth;
+    cfg.numberWrites = (cfg.baseline * cfg.writeRatio * 3600 * cfg.baselineHours) + (cfg.peak * cfg.writeRatio * 3600 * cfg.peakHours);
     cfg.writeRequestUnits = (cfg.numberWrites * cfg.writeNonTransactional * cfg.writeRequestUnitsPerItem) +
         (cfg.numberWrites * cfg.writeTransactional * 2 * cfg.writeRequestUnitsPerItem);
     cfg.dynamoCostDemandWrites = cfg.writeRequestUnits * (cfg.tableClass === 'standard' ? cfg.pricePerWRU : cfg.pricePerWRU_IA);
@@ -170,12 +171,12 @@ export function calculateStorageCost() {
 }
 
 function calculateTotalOpsSec() {
-    cfg.readsOpsSec = cfg.pricing === 'demand' ? cfg.demand * cfg.readRatio : cfg.baseline *  cfg.readRatio;
-    cfg.writesOpsSec = cfg.pricing === 'demand' ? cfg.demand *  cfg.writeRatio : cfg.baseline *  cfg.writeRatio;
+    cfg.readsOpsSec = cfg.baseline *  cfg.readRatio;
+    cfg.writesOpsSec = cfg.baseline *  cfg.writeRatio;
     cfg.totalOpsSec = cfg.readsOpsSec + cfg.writesOpsSec;
 }
 
-function logCosts(scyllaResult, costRatio) {
+function logCosts() {
     let logs = [
         `Storage: $${cfg.dynamoCostStorage.toFixed(2)}`,];
 
@@ -197,7 +198,7 @@ function logCosts(scyllaResult, costRatio) {
         `DAX: $${cfg.dynamoDaxCost.toFixed(2)}`,
         `---: ---`,
         `Total cost/month: $${cfg.dynamoCostTotal.toFixed(2)}`]);
-    console.log("config", cfg);
+
     updateSavedCosts(logs);
 }
 
@@ -270,5 +271,5 @@ export function updateCosts() {
 
     document.getElementById('costDiff').textContent = `$${formatNumber(savings)}`;
 
-    logCosts(scyllaResult, costRatio);
+    logCosts();
 }

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -102,7 +102,7 @@ export function calculateProvisionedCosts() {
     cfg.provisionedPeakWCUHours = Math.ceil(cfg.provisionedPeakWCU * cfg.peakHours);
     cfg.provisionedTotalWCUHours = Math.ceil(cfg.provisionedBaselineWCUHours + cfg.provisionedPeakWCUHours);
     cfg.dynamoCostProvisionedWCU = cfg.provisionedTotalWCUHours * (cfg.tableClass === 'standard' ? cfg.pricePerWCU : cfg.pricePerWCU_IA);
-    cfg.dynamoCostReplication = cfg.regions * cfg.provisionedTotalWCUHours * (cfg.tableClass === 'standard' ? cfg.pricePerRWRU : cfg.pricePerRWRU_IA);
+    cfg.dynamoCostReplication = (cfg.regions - 1) * cfg.provisionedTotalWCUHours * (cfg.tableClass === 'standard' ? cfg.pricePerRWRU : cfg.pricePerRWRU_IA);
     cfg.dynamoCostReservedWCU = cfg.reservedWCU * cfg.pricePerRWCU * cfg.hoursPerMonth;
     cfg.dynamoCostMonthlyWCU = cfg.dynamoCostProvisionedWCU + cfg.dynamoCostReservedWCU + cfg.dynamoCostReplication;
     cfg.dynamoCostUpfrontWCU = cfg.reservedWCU * 1.50;
@@ -148,7 +148,7 @@ export function calculateDemandCosts() {
         (cfg.numberWrites * cfg.writeTransactional * 2 * cfg.writeRequestUnitsPerItem);
     cfg.dynamoCostDemandWrites = cfg.writeRequestUnits * (cfg.tableClass === 'standard' ? cfg.pricePerWRU : cfg.pricePerWRU_IA);
 
-    cfg.dynamoCostReplication = cfg.regions * cfg.writeRequestUnits * (cfg.tableClass === 'standard' ? cfg.pricePerRWRU : cfg.pricePerRWRU_IA);
+    cfg.dynamoCostReplication = (cfg.regions -1) * cfg.writeRequestUnits * (cfg.tableClass === 'standard' ? cfg.pricePerRWRU : cfg.pricePerRWRU_IA);
 
     cfg.dynamoCostDemand = cfg.dynamoCostDemandReads + cfg.dynamoCostDemandWrites + cfg.dynamoCostReplication;
 }
@@ -156,7 +156,7 @@ export function calculateDemandCosts() {
 function calculateNetworkCosts() {
     cfg.totalReadsKB = cfg.readsOpsSec * 3600 * cfg.hoursPerMonth * cfg.itemSizeKB;
     cfg.totalWritesKB = cfg.writesOpsSec * 3600 * cfg.hoursPerMonth * cfg.itemSizeKB;
-    cfg.totalReplicatedWritesGB =( cfg.regions * cfg.totalWritesKB) / 1024 / 1024;
+    cfg.totalReplicatedWritesGB =((cfg.regions - 1) * cfg.totalWritesKB) / 1024 / 1024;
     cfg.dynamoCostNetwork = cfg.totalReplicatedWritesGB * cfg.priceIntraRegPerGB;
 }
 

--- a/src/chart.js
+++ b/src/chart.js
@@ -3,7 +3,7 @@ import {formatNumber, updateAll} from "./utils.js";
 
 const ctx = document.getElementById('chart').getContext('2d');
 
-function generateProvisionedData(baseline, peak, peakWidth) {
+function generateData(baseline, peak, peakWidth) {
     const data = [];
     const peakStart = Math.floor((24 - peakWidth) / 2);
     const peakEnd = peakStart + peakWidth;
@@ -16,10 +16,6 @@ function generateProvisionedData(baseline, peak, peakWidth) {
         }
     }
     return data;
-}
-
-function generateOnDemandData() {
-    return Array.from({length: 25}, (_, i) => ({x: i, y: cfg.demand}));
 }
 
 function generateWorkloadData(workload) {
@@ -38,8 +34,7 @@ function generateWorkloadData(workload) {
 }
 
 export function updateChart() {
-    chart.data.datasets[1].data = generateOnDemandData();
-    chart.data.datasets[2].data = generateProvisionedData(cfg.baseline, cfg.peak, cfg.peakWidth);
+    chart.data.datasets[1].data = generateData(cfg.baseline, cfg.peak, cfg.peakWidth);
     chart.update();
 }
 
@@ -55,24 +50,15 @@ export const chart = new Chart(ctx, {
             borderDash: [4, 4],
             tension: 0.3
         }, {
-            label: 'On Demand',
-            data: generateOnDemandData(),
-            borderColor: '#0F1040',
-            backgroundColor: 'rgba(15,16,64,0.8)',
-            showLine: true,
-            pointRadius: 0,
-            fill: true,
-            tension: 0.1,
-        }, {
             label: 'Provisioned',
-            data: generateProvisionedData(),
+            data: generateData(),
             borderColor: '#0F1040',
             backgroundColor: 'rgba(15,16,64,0.8)',
             fill: true,
             tension: 0.1,
             showLine: true,
             pointRadius: 0,
-            hidden: true
+            hidden: false
         }]
     }, options: {
         plugins: {

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,5 @@
 export const cfg = {
     pricing:            'demand',
-    demand:             50000,
     baseline:           50000,
     peak:               500000,
     peakWidth:          1,

--- a/src/config.js
+++ b/src/config.js
@@ -22,7 +22,7 @@ export const cfg = {
     pricePerRCU_IA:     0.00016,
     pricePerWCU_IA:     0.00081,
     // Replicated
-    regions:  0,
+    regions:  1,
     pricePerRWRU:       0.000000625,
     pricePerRWRU_IA:    0.000000780,
     // Data Transfer

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,7 +14,6 @@ export function getQueryParams() {
     const params = new URLSearchParams(window.location.search);
 
     if (params.get('workload')) cfg.workload = params.get('workload');
-    if (params.get('demand')) cfg.demand = parseInt(params.get('demand'));
     if (params.get('baseline')) cfg.baseline = parseInt(params.get('baseline'));
     if (params.get('peak')) cfg.peak = parseInt(params.get('peak'));
     if (params.get('peakWidth')) cfg.peakWidth = parseInt(params.get('peakWidth'));


### PR DESCRIPTION
Minor items:
- remove $10K/mo saved using ScyllaDB
- remove read transactions, keep read consistency
- rename Item Size -> Operation Size, move from Storage -> Operations section
- rename Global Tables -> Data Centers and use 1 based index (>1 indicates global table / multi region)

Major items:
- define workload as single item in chart then apply on-demand | provisioned calculation to the curve

Note: this deviates significantly from the way AWS calculates pricing for on-demand capacity. As such direct comparisons to AWS calculator are more amibiguous for on-demand. 