### PR TITLE
add DAX calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,32 +174,41 @@
 
   <div id="daxParams" style="display: none;">
     <div>
-      <label for="daxInstanceClass">Instance Class:
-        <select id="daxInstanceClass">
-          <option value="r5Large">dax.r5.large | 2vCPU 16GB RAM</option>
-          <option value="r5XLarge">dax.r5.xlarge | 4vCPU 32GB RAM</option>
-          <option value="r52XLarge">dax.r5.2xlarge | 8vCPU 64GB RAM</option>
-          <option value="r54XLarge">dax.r5.4xlarge | 16vCPU 128GB RAM</option>
-          <option value="r58XLarge">dax.r5.8xlarge | 32vCPU 256GB RAM</option>
-          <option value="r512XLarge">dax.r5.12xlarge | 48vCPU 384GB RAM</option>
-          <option value="r516XLarge">dax.r5.16xlarge | 64vCPU 512GB RAM</option>
-          <option value="r524XLarge">dax.r5.24xlarge | 96vCPU 768GB RAM</option>
-        </select>
+      <label for="cacheSize">Dataset Size:
+        <span id="cacheSizeDsp">0</span>
         <span class="info-icon">i
-          <span class="tooltip-text">Select the instance class for your workload.</span>
+            <span class="tooltip-text">Enter the dataset memory size that your cache will use.</span>
+        </span>
+      </label>
+      <input type="range" id="cacheSize" min="0" max="10240" step="64" value="0">
+    </div>
+
+    <div>
+      <label for="cacheRatio">Hit/Miss Ratio:
+        <span id="cacheRatioDsp">0/100</span>
+        <span class="info-icon">i
+            <span class="tooltip-text">Enter the hit miss ratio that your cache will use.</span>
+        </span>
+      </label>
+      <input type="range" id="cacheRatio" min="0" max="100" step="1" value="0">
+    </div>
+
+    <div>
+      <label>Instance Class:
+        <span id="daxInstanceClass">none</span>
+        <span class="info-icon">i
+            <span class="tooltip-text">This is the recommended instance class for your workload.</span>
         </span>
       </label>
     </div>
 
     <div>
-      <label for="daxNodes">Number of Nodes:
-        <input type="text" id="daxNodesInp" style="display: none; width: 80px; cursor: pointer;">
-        <span id="daxNodesDsp">0</span>
+      <label>Number of Nodes:
+        <span id="daxNodes">0</span>
         <span class="info-icon">i
-            <span class="tooltip-text">Enter the number of nodes for your workload.</span>
+            <span class="tooltip-text">This is the recommended minimum number of nodes for your workload.</span>
         </span>
       </label>
-      <input type="range" id="daxNodes" min="0" max="24" step="3" value="0">
     </div>
   </div>
 </div>

--- a/src/app.js
+++ b/src/app.js
@@ -94,7 +94,6 @@ setupSliderInteraction('peakWidthDsp', 'peakWidthInp', 'peakWidth', value => val
 setupSliderInteraction('itemSizeDsp', 'itemSizeInp', 'itemSizeB', value => value < 1024 ? `${value} B` : `${Math.floor(value / 1024)} KB`);
 setupSliderInteraction('storageDsp', 'storageInp', 'storageGB', value => value >= 1024 ? (value / 1024).toFixed(2) + ' TB' : value + ' GB');
 setupSliderInteraction('regionsDsp', 'regionsInp', 'regions', value => value);
-setupSliderInteraction('daxNodesDsp', 'daxNodesInp', 'daxNodes', value => value);
 
 document.getElementById('chart').onclick = function (event) {
     clickHandler(event);
@@ -238,8 +237,18 @@ readTrans.addEventListener('input', () => {
     updateReadConsistency();
 });
 
-document.getElementById('daxInstanceClass').addEventListener('change', (event) => {
-    cfg.daxInstanceClass = event.target.value;
+document.getElementById('cacheSize').addEventListener('input', (event) => {
+    const cacheSizeGB = parseInt(event.target.value);
+    document.getElementById('cacheSizeDsp').innerText = cacheSizeGB >= 1024 ? (cacheSizeGB / 1024).toFixed(2) + ' TB' : cacheSizeGB + ' GB';
+    cfg.cacheSizeGB = cacheSizeGB;
+    updateAll();
+});
+
+document.getElementById('cacheRatio').addEventListener('input', (event) => {
+    const cacheHitRatio = parseInt(event.target.value);
+    const cacheMissRatio = 100 - cacheHitRatio;
+    document.getElementById('cacheRatioDsp').innerText = `${cacheHitRatio}/${cacheMissRatio}`;
+    cfg.cacheRatio = cacheHitRatio;
     updateAll();
 });
 
@@ -260,7 +269,8 @@ document.getElementById('itemSizeB').value = cfg.itemSizeB;
 document.getElementById('storageGB').value = cfg.storageGB;
 document.getElementById('ratio').value = cfg.ratio;
 document.getElementById('regions').value = cfg.regions;
-document.getElementById('daxNodes').value = cfg.daxNodes;
+document.getElementById('cacheSize').value = cfg.cacheSizeGB;
+document.getElementById('cacheRatio').value = cfg.cacheRatio;
 
 document.getElementById('baselineDsp').innerText = formatNumber(cfg.baseline);
 document.getElementById('peakDsp').innerText = formatNumber(cfg.peak);
@@ -269,6 +279,7 @@ document.getElementById('itemSizeDsp').innerText = cfg.itemSizeB < 1024 ? `${cfg
 document.getElementById('storageDsp').innerText = cfg.storageGB >= 1024 ? (cfg.storageGB / 1024).toFixed(2) + ' TB' : cfg.storageGB + ' GB';
 document.getElementById('ratioDsp').innerText = `${cfg.ratio}/${100 - cfg.ratio}`;
 document.getElementById('regionsDsp').innerText = cfg.regions;
-document.getElementById('daxNodesDsp').innerText = cfg.daxNodes;
+document.getElementById('cacheSizeDsp').innerText = cfg.cacheSizeGB >= 1024 ? (cfg.cacheSizeGB / 1024).toFixed(2) + ' TB' : cfg.cacheSizeGB + ' GB';
+document.getElementById('cacheRatioDsp').innerText = `${cfg.cacheRatio}/${100 - cfg.cacheRatio}`;
 
 updateAll();

--- a/src/config.js
+++ b/src/config.js
@@ -27,17 +27,19 @@ export const cfg = {
     // Data Transfer
     priceIntraRegPerGB: 0.02,
     // DAX Node Costs
+    cacheSizeGB:        0,
+    cacheRatio:         0,
     daxNodes:           0,
-    daxInstanceClassCosts: {
-    r5Large:            0.25500000,
-    r5XLarge:           0.50900000,
-    r52XLarge:          1.01700000,
-    r54XLarge:          2.03400000,
-    r58XLarge:          4.06900000,
-    r512XLarge:         6.11700000,
-    r516XLarge:         8.13700000,
-    r524XLarge:        12.23400000,
-    },
+    daxInstanceClassCosts: [
+        { instance: "dax.r5.large", memory: 16, nps: 75000, price: 0.25500000 },
+        { instance: "dax.r5.xlarge", memory: 32, nps: 150000, price: 0.50900000 },
+        { instance: "dax.r5.2xlarge", memory: 64, nps: 300000, price: 1.01700000 },
+        { instance: "dax.r5.4xlarge", memory: 128, nps: 600000, price: 2.03400000 },
+        { instance: "dax.r5.8xlarge", memory: 256, nps: 1000000, price: 4.06900000 },
+        { instance: "dax.r5.12xlarge", memory: 384, nps: 1000000, price: 6.12000000 },
+        { instance: "dax.r5.16xlarge", memory: 512, nps: 1000000, price: 8.13700000 },
+        { instance: "dax.r5.24xlarge", memory: 768, nps: 1000000, price: 12.24000000 },
+    ],
     scyllaPrices: [
         {
             family: "i4i", instance: "i4i.xlarge", baseline: 78000, peak: 120000, storage: 937, price: 3.325


### PR DESCRIPTION
Add auto calculations for DAX workload based on working set size and cache hit ratio.

Does not consider node loss tolerance.
![CleanShot 2025-02-21 at 16 15 03@2x](https://github.com/user-attachments/assets/91eedcb5-f690-4b6d-a53c-3eb562bffdc3)
